### PR TITLE
Add coming_soon route to display upcoming features

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -65,6 +65,16 @@ def innovation_news():
         return jsonify({"error": articles["error"]}), 500
     return jsonify({"articles": articles}), 200
 
+# New Route for Coming Soon Features
+@fact_checker.route("/coming_soon", methods=["GET"])
+def coming_soon():
+    upcoming_features = [
+        {"feature": "User Profile Management", "status": "In Development"},
+        {"feature": "Achievements Leaderboard", "status": "Planned"},
+        {"feature": "Real-Time Notifications", "status": "In Planning"}
+    ]
+    return jsonify({"coming_soon": upcoming_features}), 200
+
 # Auth Blueprint for user authentication routes
 auth_bp = Blueprint('auth', __name__)
 


### PR DESCRIPTION
**Description:**  
This PR introduces a new route, `/coming_soon`, to provide a list of upcoming features.  

### **Changes:**  
- Added a new `GET /coming_soon` endpoint.  
- Returns a JSON response with a list of planned and in-development features.  

This prepares the API for displaying upcoming functionalities to users.